### PR TITLE
Update onfido-carthage-spec.json with missing version

### DIFF
--- a/onfido-carthage-spec.json
+++ b/onfido-carthage-spec.json
@@ -1,4 +1,6 @@
 {
+  "16.1.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v16.0.0.zip",
+  "16.0.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v16.0.0.zip",
   "15.0.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v15.0.0.zip",
   "14.0.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v14.0.0.zip",
   "14.0.0-rc": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v14.0.0-rc.zip",
@@ -11,6 +13,5 @@
   "12.0.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-Debug-v12.0.0.zip",
   "11.1.2": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-Debug-v11.1.2.zip",
   "11.1.1": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-Debug-v11.1.1.zip",
-  "11.1.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-Debug-v11.1.0.zip",
-  "16.0.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-v16.0.0.zip"
+  "11.1.0": "https://s3-eu-west-1.amazonaws.com/onfido-sdks/ios/Onfido-Debug-v11.1.0.zip"
 }


### PR DESCRIPTION
Our publish doc script didn't consider updating  onfido-carthage-spec.json so I added it manually and also put the new versions at the top.

